### PR TITLE
Typo fix in CV page

### DIFF
--- a/pages/CV/index.md
+++ b/pages/CV/index.md
@@ -25,7 +25,7 @@ toc: true
 
 **Professorial Chair of Earth Sciences (Geophysics), University of Melbourne.** Research in computational geodynamics with application areas in mineral, petroleum and geothermal exploration,  planetary evolution, geology and industrial flows. Expert in finite element software, algorithm design, numerical solvers, parallelism, and efficient implementation.
 
-##Employment
+## Employment
 
  **2014-Present:**    Professorial Chair of Earth Sciences (Geophysics), University of Melbourne <br>
  **2014-Present:**    Senior Research Scientist (part time), Dept of Earth Sciences, University of Southern California <br>


### PR DESCRIPTION
@lmoresi was looking at your page (following links from Underworld) and noticed a small typo in the CV. The "Employment" section was missing a space between the section marker (`##`), making it not render the HTML properly.

I like the page design and your posts. Added several to my coffee-time reading list.


